### PR TITLE
Register vulnerability

### DIFF
--- a/activities/Auth/Auth.php
+++ b/activities/Auth/Auth.php
@@ -106,7 +106,7 @@ class Auth
                 if ($result) {
                     $request['verify_token'] = $randomToken;
                     $request['password'] = $this->hash($request['password']);
-                    $db->insert('users', array_keys($request), $request);
+                    $db->insert('users', ['email', 'password', 'username', 'verify_token'], [$request['email'], $request['password'], $request['username'], $request['verify_token']]);
                     $this->redirect('login');
                 }
 


### PR DESCRIPTION
Resolved vulnerability where user could assign himself admin permissions or activation even without email verification.

During registration user can assign himself admin permissions if in the same request user will send form data 'permission: admin'. As register route does not check whether request contains this field this can be considered a serious exploit. In addition, user can also immediately activate his account during registration if is_active parameter is set.

Below is shown an example request that would allow user to register an account without email confirmation as well as with admin permissions.
![image](https://github.com/MobinaJafarian/OnlineNewsSite/assets/80958300/273104e8-bd16-46b0-b467-d6f73584597b)

Fix is simple, do not trust all the data user provided in his request as it can contain more than fields than the rest api handler actually needs. Insert only known parameters into the database.